### PR TITLE
Add Spanish "es-mx" Support and Translate README in root

### DIFF
--- a/translations/es-mx/README.md
+++ b/translations/es-mx/README.md
@@ -1,0 +1,97 @@
+
+![IA Generativa para principiantes](../../images/repository-thumbnail.png?WT.mc_id=academic-105485-koreyst)
+
+### Un curso de 12 lecciones que enseña todo lo que necesitas saber para comenzar a crear aplicaciones de IA Generativa
+
+[![GitHub license](https://img.shields.io/github/license/microsoft/Generative-AI-For-Beginners.svg)](https://github.com/microsoft/Generative-AI-For-Beginners/blob/master/LICENSE?WT.mc_id=academic-105485-koreyst)
+[![GitHub contributors](https://img.shields.io/github/contributors/microsoft/Generative-AI-For-Beginners.svg)](https://GitHub.com/microsoft/Generative-AI-For-Beginners/graphs/contributors/?WT.mc_id=academic-105485-koreyst)
+[![GitHub issues](https://img.shields.io/github/issues/microsoft/Generative-AI-For-Beginners.svg)](https://GitHub.com/microsoft/Generative-AI-For-Beginners/issues/?WT.mc_id=academic-105485-koreyst)
+[![GitHub pull-requests](https://img.shields.io/github/issues-pr/microsoft/Generative-AI-For-Beginners.svg)](https://GitHub.com/microsoft/Generative-AI-For-Beginners/pulls/?WT.mc_id=academic-105485-koreyst)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com?WT.mc_id=academic-105485-koreyst)
+
+[![GitHub watchers](https://img.shields.io/github/watchers/microsoft/Generative-AI-For-Beginners.svg?style=social&label=Watch)](https://GitHub.com/microsoft/Generative-AI-For-Beginners/watchers/?WT.mc_id=academic-105485-koreyst)
+[![GitHub forks](https://img.shields.io/github/forks/microsoft/Generative-AI-For-Beginners.svg?style=social&label=Fork)](https://GitHub.com/microsoft/Generative-AI-For-Beginners/network/?WT.mc_id=academic-105485-koreyst)
+[![GitHub stars](https://img.shields.io/github/stars/microsoft/Generative-AI-For-Beginners.svg?style=social&label=Star)](https://GitHub.com/microsoft/Generative-AI-For-Beginners/stargazers/?WT.mc_id=academic-105485-koreyst)
+
+[![Open in GitHub Codespaces](https://img.shields.io/static/v1?style=for-the-badge&label=GitHub+Codespaces&message=Open&color=lightgrey&logo=github)](https://codespaces.new/microsoft/generative-ai-for-beginners?WT.mc_id=academic-105485-koreyst)
+[![](https://dcbadge.vercel.app/api/server/ByRwuEEgH4)](https://aka.ms/genai-discord?WT.mc_id=academic-105485-koreyst)
+
+
+# IA Generativa para Principiantes - Un Curso
+
+Aprende los fundamentos de la creación de aplicaciones de IA Generativa con nuestro curso integral de 12 lecciones impartido por los Microsoft Cloud Advocates. Cada lección cubre un aspecto clave de los principios de la IA Generativa y el desarrollo de aplicaciones. A lo largo de este curso, estarás creando tu propia startup de IA Generativa para que puedas comprender lo que se necesita para lanzar tus ideas.
+
+### 🌟 Agradecimientos especiales
+A nuestros Microsoft Student Ambassadors y autores, revisores, y colaboradores de contenido de la comunidad, incluidos: 
+
+[**John Aziz**](https://www.linkedin.com/in/john0isaac/) - Por crear todos los GitHub Actions y workflows
+
+
+
+## 🌱 Primeros Pasos
+
+Para comenzar, [haz fork de este repositorio](https://github.com/microsoft/generative-ai-for-beginners/fork?WT.mc_id=academic-105485-koreyst) en tu propia cuenta de GitHub para poder cambiar cualquier código y completar los desafíos. También puedes [marcar con una estrella (🌟) este repositorio](https://docs.github.com/en/get-started/exploring-projects-on-github/saving-repositories-with-stars?WT.mc_id=academic-105485-koreyst) para encontrarlo más fácilmente más tarde.
+
+A continuación se muestran los enlaces a cada lección. ¡Siéntete libre de explorar y comenzar con cualquier lección que más te interese!
+
+Dirígete a la [Página de Configuración del Curso](../../00-course-setup/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) para encontrar la guía de configuración que mejor se adapte a tus necesidades. 
+
+## 🗣️ Conoce a Otros Estudiantes, Obtén Soporte 
+
+¡Una de las mejores maneras de aprender es aprendiendo con otras personas! Únete a nuestro [servidor oficial de Discord de IA](https://aka.ms/genai-discord?WT.mc_id=academic-105485-koreyst) para conocer y establecer contactos con otros estudiantes que toman este curso y obtener soporte. ¿Quién sabe? ¡Quizás encuentres allí a tu próximo cofundador!
+
+## 🧠 ¿Quieres aprender más?
+Después de completar este curso, ¡consulta nuestra [colección de Aprendizaje de IA Generativa](https://aka.ms/genai-collection?WT.mc_id=academic-105485-koreyst) para continuar mejorando tu conocimiento de IA Generativa! 
+
+##  🚀  ¿Eres una startup o tienes una idea que quieres lanzar? 
+
+Regístrate en [Microsoft for Startups Founders Hub](https://aka.ms/genai-foundershub?WT.mc_id=academic-105485-koreyst) para recibir **créditos gratuitos de OpenAI** y hasta **$150k en créditos de Azure para acceder a modelos OpenAI a través de Azure OpenAI Services**. 
+
+##  🙏 ¿Deseas ayudar?
+
+A continuación se muestran formas en las que puedes contribuir a este curso: 
+- Encuentra errores de ortografía o de código, [crea una issue](https://github.com/microsoft/generative-ai-for-beginners/issues?WT.mc_id=academic-105485-koreyst) o [haz un pull request](https://github.com/microsoft/generative-ai-for-beginners/pulls?WT.mc_id=academic-105485-koreyst)
+- Envíanos tus ideas, tal vez tus ideas para nuevas lecciones o ejercicios, y cuéntanos cómo podemos mejorar.
+
+
+## 📂 Cada lección incluye
+
+- un breve video de introducción al tema
+- una lección escrita ubicada en el README
+- un Jupyter Notebook con ejemplos de código (para lecciones basadas en proyectos)
+- un desafío o tarea para aplicar lo aprendido
+- links a recursos adicionales para continuar tu aprendizaje
+
+## 🗃️ Lecciones
+|       |              Link a la Lección              |                       Conceptos Enseñados                       |                     Objetivo de Aprendizaje                 |                             
+| :---: | :------------------------------------: | :---------------------------------------------------------: | ----------------------------------------------------------- |
+| 00 | [Introducción al Curso - Cómo Realizar Este Curso](../../00-course-setup/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | Configuración técnica y estructura del curso | Preparándote para el éxito mientras aprendes en este curso | 
+| 01 | [Introducción a IA Generativa y LLMs](../../01-introduction-to-genai/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | **Concepto**: IA Generativa y el panorama tecnológico actual |  Comprender qué es IA Generativa y cómo funcionan los Modelos Grandes de Lenguaje (LLMs)                    |
+| 02 | [Explorando y comparando diferentes LLMs](../../02-exploring-and-comparing-different-llms/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | **Concepto**: Probar, iterar y comparar diferentes Modelos Grandes de Lenguaje | Selecciona el modelo adecuado para tu caso de uso | 
+| 03 | [Usando IA Generativa de manera Responsable](../../03-using-generative-ai-responsibly/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst)| **Concepto:** Comprender las limitaciones de los modelos fundacionales y los riesgos detrás de la IA | Aprende a crear Aplicaciones de IA Generativa de forma responsable 
+| 04 | [Comprendiendo los Fundamentos de Prompt Engineering](../../04-prompt-engineering-fundamentals/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | **Código/Concepto:** Aplicación práctica de las Mejores Prácticas de Ingeniería de Prompts  |  Comprender la estructura y el uso de los prompts |  
+| 05 | [Creando Prompts Avanzados](../../05-advanced-prompts/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | **Código/Concepto:** Extiende tu conocimiento de ingeniería de prompts aplicando diferentes técnicas a tus prompts | Aplica técnicas de ingeniería de prompts que mejoren el resultado de tus prompts| 
+| 06 | [Creando Aplicaciones de Generación de Texto](../../06-text-generation-apps/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst)  | **Código:** Crea una aplicación de generación de texto usando Azure OpenAI  | Comprende cómo utilizar eficientemente los tokens y la temperatura para variar la salida del modelo | |
+| 07 | [Creando Aplicaciones de Chat](../../07-building-chat-applications/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | **Código**: Técnicas para crear e integrar aplicaciones de chat eficientemente.| Identifica métricas y consideraciones clave para monitorear y mantener de manera efectiva la calidad de aplicaciones de chat impulsadas por IA | 
+| 08 | [Creando Aplicaciones de Búsqueda con Bases de Datos Vectoriales](../../08-building-search-applications/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | **Código**: Búsqueda Semántica vs Búsqueda por Palabras Clave. Aprende sobre embeddings de texto y cómo se aplican a la búsqueda | Crea una aplicación que usa Embeddings para buscar datos | 
+| 09 | [Creando Aplicaciones de Generación de Imágenes](../../09-building-image-applications/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst)  | **Código:** Generación de imágenes y por qué es útil en la creación de aplicaciones | Crea una aplicación de generación de imágenes | 
+| 10 | [Construyendo Aplicaciones de IA de Low Code](../../10-building-low-code-ai-applications/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst)  | **Código Bajo:** Introducción a la IA Generativa en Power Platform | Crea una Aplicación de Seguimiento de Tareas de Estudiantes para nuestra startup educativa con Low Code | |
+| 11 | [Integrando Aplicaciones Externas con Llamadas a Funciones](../../11-integrating-with-function-calling/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst)  | **Código:** Qué son las llamadas a funciones y sus casos de uso para aplicaciones  | Configura una llamada de función para recuperar datos de una API externa | |
+| 12 | [Diseñando UX para Aplicaciones de IA](../../12-designing-ux-for-ai-applications/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst) | **Concepto:** Diseño de aplicaciones de IA para generar Confianza y Transparencia | Aplica principios de diseño de UX al desarrollar Aplicaciones de IA Generativa | |
+| xx | [Continua Tu Aprendizaje](../../13-continued-learning/translations/es-mx/README.md?WT.mc_id=academic-105485-koreyst)  | ¡Links para continuar tu aprendizaje de cada lección! | Domina tus habilidades de IA Generativa | |
+
+
+
+ 
+  
+## 🎒  Otros Cursos 
+
+¡Nuestro equipo produce otros cursos! Revisa:
+
+- [ML para Principiantes](https://aka.ms/ml-beginners?WT.mc_id=academic-105485-koreyst)
+- [Ciencia de Datos para Principiantes](https://aka.ms/datascience-beginners?WT.mc_id=academic-105485-koreyst)
+- [IA para Principiantes](https://aka.ms/ai-beginners?WT.mc_id=academic-105485-koreyst)
+- [Desarrollo Web para Principiantes](https://aka.ms/webdev-beginners?WT.mc_id=academic-105485-koreyst)
+- [IoT para Principiantes](https://aka.ms/iot-beginners?WT.mc_id=academic-105485-koreyst)
+- [Desarrollo XR para Principiantes](https://github.com/microsoft/xr-development-for-beginners?WT.mc_id=academic-105485-koreyst)
+- [Domina GitHub Copilot para Paired Programming con IA](https://aka.ms/GitHubCopilotAI?WT.mc_id=academic-105485-koreyst)


### PR DESCRIPTION
Closes #2 

1. Creation of es-mx folder in root: A new folder named 'es-mx' has been added to house the Spanish-specific translations.
2. Addition of README: Within the 'es-mx' folder, a README.md file has been included to provide an overview and guidance for the translated content in the welcome page.

I would like to request a review from @ppiova to ensure the accuracy and quality of the translation.

These changes aim to enhance accessibility and understanding for users who prefer to interact with the content in Mexican Spanish, thereby broadening the audience and facilitating a more inclusive user experience.